### PR TITLE
multiple request per file support

### DIFF
--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -46,16 +46,3 @@ pub struct DataRequest {
     pub show_status: bool,
     pub show_time: bool,
 }
-
-impl DataRequest {
-    pub fn new(name: &str, request: Request) -> Self {
-        Self {
-            name: name.to_string(),
-            request,
-            show_error: true,
-            show_output: true,
-            show_time: true,
-            show_status: true,
-        }
-    }
-}

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -70,15 +70,10 @@ pub fn get_data_request_from_json(file_path: String) -> Result<Vec<DataRequest>,
         };
 
         for request in requests {
-            let request_url = use_global_field(
-                get_url(&request, &file_path, is_multiple_requests),
-                url.clone(),
-            )?;
+            let request_url = use_global_field(get_url(&request, &file_path, false), url.clone())?;
 
-            let request_method = use_global_field(
-                get_method(&request, &file_path, is_multiple_requests),
-                method.clone(),
-            )?;
+            let request_method =
+                use_global_field(get_method(&request, &file_path, false), method.clone())?;
 
             let request_body = get_body(&request);
 

--- a/src/parser/file.rs
+++ b/src/parser/file.rs
@@ -1,9 +1,9 @@
 use super::file_helper::{
-    get_body, get_headers, get_log_option, get_method, get_url, read_and_get_json,
+    craft_data_request, get_body, get_headers, get_log_option, get_method, get_url,
+    read_and_get_json, use_global_field, validate_field,
 };
-use crate::http::types::{DataRequest, Request};
-use reqwest::Method;
-use serde_json::json;
+use crate::http::types::DataRequest;
+use reqwest::header::HeaderMap;
 
 pub fn get_data_request_from_json(file_path: String) -> Result<Vec<DataRequest>, ()> {
     // Read & get json from file
@@ -14,72 +14,109 @@ pub fn get_data_request_from_json(file_path: String) -> Result<Vec<DataRequest>,
     let is_multiple_requests = requests.is_some();
 
     // get fields
-    let url: Option<String> = match get_url(&json, &file_path, is_multiple_requests) {
-        Ok(url) => Some(url),
-        Err(_) => {
-            if !is_multiple_requests {
-                return Err(());
-            }
-            None
-        }
-    };
+    let url = validate_field(
+        get_url(&json, &file_path, is_multiple_requests),
+        is_multiple_requests,
+    )?;
 
-    let method: Option<Method> = match get_method(&json, &file_path) {
-        Ok(method) => Some(method),
-        Err(_) => {
-            if !is_multiple_requests {
-                return Err(());
-            }
-            None
-        }
-    };
+    let method = validate_field(
+        get_method(&json, &file_path, is_multiple_requests),
+        is_multiple_requests,
+    )?;
 
     let body = get_body(&json);
-    let headers = match get_headers(&json, &file_path) {
-        Ok(headers) => Some(headers),
-        Err(_) => {
-            if !is_multiple_requests {
-                return Err(());
-            }
-            None
-        }
-    };
+    let headers = validate_field(get_headers(&json, &file_path), is_multiple_requests)?;
 
-    let show_error = get_log_option("show_error", &json, &file_path);
-    let show_output = get_log_option("show_output", &json, &file_path);
-    let show_status = get_log_option("show_status", &json, &file_path);
-    let show_time = get_log_option("show_time", &json, &file_path);
+    let show_error = validate_field(
+        get_log_option("show_error", &json, &file_path, None),
+        is_multiple_requests,
+    )?;
+    let show_output = validate_field(
+        get_log_option("show_output", &json, &file_path, None),
+        is_multiple_requests,
+    )?;
+    let show_status = validate_field(
+        get_log_option("show_status", &json, &file_path, None),
+        is_multiple_requests,
+    )?;
+    let show_time = validate_field(
+        get_log_option("show_time", &json, &file_path, None),
+        is_multiple_requests,
+    )?;
 
     // get request if multiple requests
-    let mut requests: Vec<DataRequest> = vec![];
+    let mut data_requests: Vec<DataRequest> = vec![];
 
     if !is_multiple_requests {
-        let name = json!(format!(
-            "{}:{}",
-            // Calling unwrap because we know this file only contains on request
-            method.as_ref().unwrap(),
-            url.as_ref().unwrap()
-        ));
-        let name = json.get("name").unwrap_or_else(|| &name).to_string(); // if name not exist, combining method:url, eg: GET:https://sample.api
-
-        // Building request
-        let request = Request {
-            url: url.unwrap(),
-            method: method.unwrap(),
+        let request = craft_data_request(
+            &json,
+            url.unwrap(),
+            method.unwrap(),
             body,
-            headers: headers.unwrap(),
+            headers.unwrap(),
+            show_error.unwrap(),
+            show_output.unwrap(),
+            show_status.unwrap(),
+            show_time.unwrap(),
+        );
+        data_requests.push(request)
+    } else {
+        let requests = match requests.unwrap().as_array() {
+            Some(requests) => requests.to_owned(),
+            None => {
+                eprintln!("[-] FIELD `requests` IS NOT A VALID ARRAY");
+                return Err(());
+            }
         };
 
-        requests.push(DataRequest {
-            name,
-            request,
-            show_error,
-            show_output,
-            show_status,
-            show_time,
-        })
+        for request in requests {
+            let request_url = use_global_field(
+                get_url(&request, &file_path, is_multiple_requests),
+                url.clone(),
+            )?;
+
+            let request_method = use_global_field(
+                get_method(&request, &file_path, is_multiple_requests),
+                method.clone(),
+            )?;
+
+            let request_body = get_body(&request);
+
+            let mut request_headers = HeaderMap::new();
+            let headers_in_request = get_headers(&request, &file_path)?;
+
+            if headers.clone().is_some() {
+                request_headers = headers.clone().unwrap();
+
+                for (k, v) in headers_in_request.iter() {
+                    request_headers.append(k.to_owned(), v.to_owned());
+                }
+            }
+
+            let request_show_error =
+                get_log_option("show_error", &request, &file_path, show_error)?;
+            let request_show_output =
+                get_log_option("show_output", &request, &file_path, show_output)?;
+            let request_show_status =
+                get_log_option("show_status", &request, &file_path, show_status)?;
+            let request_show_time = get_log_option("show_time", &request, &file_path, show_time)?;
+
+            let data_request = craft_data_request(
+                &json,
+                request_url,
+                request_method,
+                request_body,
+                request_headers,
+                request_show_error,
+                request_show_output,
+                request_show_status,
+                request_show_time,
+            );
+
+            data_requests.push(data_request);
+        }
     }
 
     // returning DataRequest
-    Ok(requests)
+    Ok(data_requests)
 }


### PR DESCRIPTION
Users can send json file with multiple requests in it, by including a field named `requests` with array of requests.

The fields in root will use as global variable, (in this case method will be `GET` for both requests), you can override this functionality by specifying field in request.

example
```json
{
  "method": "GET",
  "requests": [
      {
        "url": "https://jsonplaceholder.typicode.com/todos"
      },
      {
        "url": "https://jsonplaceholder.typicode.com/users"
      }
   ]
}
```